### PR TITLE
xml error fixed

### DIFF
--- a/Exporting files from the host app/com.cep.export/CSXS/manifest.xml
+++ b/Exporting files from the host app/com.cep.export/CSXS/manifest.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <!--
 Copyright 2018 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -9,8 +10,6 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
  -->
-
-<?xml version='1.0' encoding='UTF-8'?>
 <ExtensionManifest ExtensionBundleId="com.cep.export" ExtensionBundleVersion="1.0.0" Version="7.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ExtensionList>
     <Extension Id="com.cep.export.panel" Version="1.0.0" />

--- a/Network requests and responses with Fetch/com.cep.weather-simple/CSXS/manifest.xml
+++ b/Network requests and responses with Fetch/com.cep.weather-simple/CSXS/manifest.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <!-- 
 Copyright 2018 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -9,7 +10,6 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 -->
-<?xml version='1.0' encoding='UTF-8'?>
 <ExtensionManifest ExtensionBundleId="com.cep.weather-simple" ExtensionBundleVersion="1.0.0" Version="7.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ExtensionList>
     <Extension Id="com.cep.weather-simple.panel" Version="1.0.0" />


### PR DESCRIPTION
# Submit a pull request

## CLA

- [Y ] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [ ] A guide contained within this repo.
- [Y ] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:


## Versions

- [8.0 ] CEP version(s) tested [must be `8.x+` for this repo]:
- [PS ] Supported/tested CC app(s) and version(s):


## Description of the pull request

Host apps expect to see the first line of xml configuration lines at the top of the xml file. So I moved the copyrights comment right below the first line.
