### PR TITLE
Fixed the extensionId to align with the manifest

### DIFF
--- a/Exporting files from the host app/com.cep.export/.debug
+++ b/Exporting files from the host app/com.cep.export/.debug
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ExtensionList>
-  <Extension Id="com.cep.export">
+  <Extension Id="com.cep.export.panel">
     <HostList>
       <Host Name="PHXS" Port="8088" />
       <Host Name="IDSN" Port="8087" />


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Adobe CLA](http://adobe.github.io/cla.html) (required).

## Topic

This is a pull request for:

- [ ] A guide contained within this repo.
- [x] A sample contained within this repo.
- [ ] Something new that I have already discussed with Adobe in a GitHub issue. Issue link:


## Versions

- [x] CEP version(s) tested [must be `8.x+` for this repo]:
- [ ] Supported/tested CC app(s) and version(s):


## Description of the pull request
The extensionId in .debug file in the export file sample is not consistent with that of its manifest, making it unable to use remote debugging.